### PR TITLE
feat: Update trust for Blender

### DIFF
--- a/autopkg_src/overrides/Blender.munki.recipe
+++ b/autopkg_src/overrides/Blender.munki.recipe
@@ -43,18 +43,18 @@
 			<key>io.github.hjuutilainen.download.Blender</key>
 			<dict>
 				<key>git_hash</key>
-				<string>d3c9df4fab10c25867133a825e2ed5e2fde5d08e</string>
+				<string>783f66cf51e8e0cda597f80f5462395344eb96f3</string>
 				<key>path</key>
-				<string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes/Blender/Blender.download.recipe</string>
+				<string>~/work/automunki/automunki/autopkg_src/repos/com.github.autopkg.hjuutilainen-recipes/Blender/Blender.download.recipe</string>
 				<key>sha256_hash</key>
-				<string>66d6c1212cf4e786bfd54957facc531e83dafe4a688c23570cce58181f36d6c8</string>
+				<string>cef4c7e1b450558cac03052b4e8cbd786ec493705742a66b5048763bec054840</string>
 			</dict>
 			<key>io.github.hjuutilainen.munki.Blender</key>
 			<dict>
 				<key>git_hash</key>
 				<string>182786eea79ea18b3640d64a8d7fd1faf2374bda</string>
 				<key>path</key>
-				<string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes/Blender/Blender.munki.recipe</string>
+				<string>~/work/automunki/automunki/autopkg_src/repos/com.github.autopkg.hjuutilainen-recipes/Blender/Blender.munki.recipe</string>
 				<key>sha256_hash</key>
 				<string>737b97fb340338f54cce543a572d25fea287e5583ac0b55b105c17b3d45fb17e</string>
 			</dict>


### PR DESCRIPTION
autopkg_src/overrides/Blender.munki.recipe: FAILED
    Parent recipe io.github.hjuutilainen.download.Blender contents differ from expected.
        Path: /Users/runner/work/automunki/automunki/autopkg_src/repos/com.github.autopkg.hjuutilainen-recipes/Blender/Blender.download.recipe
    commit 783f66cf51e8e0cda597f80f5462395344eb96f3
    Author: Tony P <tonypaco@mac.com>
    Date:   Tue Jun 6 09:35:24 2023 -0500
    
        Update Blender.download.recipe
        
        Addition of " to second URLTextSearcher pattern to avoid return of url like
        'url': 'https://mirror.clarkson.edu/blender/release/Blender3.5/blender-3.5.1-macos-x64.dmg">https://mirror.clarkson.edu/blender/release/Blender3.5/blender-3.5.1',
    diff --git a/Blender/Blender.download.recipe b/Blender/Blender.download.recipe
    index 29321ff..d2c573c 100644
    --- a/Blender/Blender.download.recipe
    +++ b/Blender/Blender.download.recipe
    @@ -40,7 +40,7 @@
     				<key>url</key>
     				<string>https://www.blender.org/download/release/%download_path%</string>
     				<key>re_pattern</key>
    -				<string>(?P&lt;url&gt;https://.*/blender-(?P&lt;version&gt;[0-9a-zA-Z\.]+)-macos-%ARCHITECTURE%.dmg)</string>
    +				<string>"(?P&lt;url&gt;https://.*/blender-(?P&lt;version&gt;[0-9a-zA-Z\.]+)-macos-%ARCHITECTURE%.dmg)"</string>
     			</dict>
     		</dict>
     		<dict>
    
