### PR TITLE
feat: Update trust for GoogleChrome

### DIFF
--- a/autopkg_src/overrides/GoogleChrome.munki.recipe
+++ b/autopkg_src/overrides/GoogleChrome.munki.recipe
@@ -45,18 +45,18 @@ current_user=$(/usr/bin/stat -f "%Su" /dev/console)
 			<key>com.github.autopkg.download.googlechrome</key>
 			<dict>
 				<key>git_hash</key>
-				<string>b0efb8ccf08c2e7f3774134352a3c5dbafc8</string>
+				<string>b0efb8ccf082444c2e7f3774134352a3c5dbafc8</string>
 				<key>path</key>
-				<string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/GoogleChrome/GoogleChrome.download.recipe</string>
+				<string>~/work/automunki/automunki/autopkg_src/repos/com.github.autopkg.recipes/GoogleChrome/GoogleChrome.download.recipe</string>
 				<key>sha256_hash</key>
-				<string>2bdc3f2e3cbdca9c97f5483554a22c48cc078a9c170e57bb6fd2a4d676</string>
+				<string>2bdc3f2e3cbdca9c01181f97f5483554a22c48cc078a9c170e57bb6fd2a4d676</string>
 			</dict>
 			<key>com.github.autopkg.munki.google-chrome</key>
 			<dict>
 				<key>git_hash</key>
 				<string>5f5db38265797f1754def56335de7bfc75811305</string>
 				<key>path</key>
-				<string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/GoogleChrome/GoogleChrome.munki.recipe</string>
+				<string>~/work/automunki/automunki/autopkg_src/repos/com.github.autopkg.recipes/GoogleChrome/GoogleChrome.munki.recipe</string>
 				<key>sha256_hash</key>
 				<string>8fd2feaa1c196109ee3bc4149b2447936782336f913c39875a4ad6c3e6dc4baa</string>
 			</dict>


### PR DESCRIPTION
autopkg_src/overrides/GoogleChrome.munki.recipe: FAILED
    Parent recipe com.github.autopkg.download.googlechrome contents differ from expected.
        Path: /Users/runner/work/automunki/automunki/autopkg_src/repos/com.github.autopkg.recipes/GoogleChrome/GoogleChrome.download.recipe
    
