### PR TITLE
feat: Update trust for Postman

### DIFF
--- a/autopkg_src/overrides/Postman.munki.recipe
+++ b/autopkg_src/overrides/Postman.munki.recipe
@@ -62,20 +62,20 @@
 			<key>com.github.dataJAR-recipes.download.postman</key>
 			<dict>
 				<key>git_hash</key>
-				<string>885ab794db5007bb8d83fd2aa06edbdde3f5b9f7</string>
+				<string>86f0ee3f3344a8895a39f2d6ab7c8ea0dad58e28</string>
 				<key>path</key>
-				<string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes/Postman/Postman.download.recipe</string>
+				<string>~/work/automunki/automunki/autopkg_src/repos/com.github.autopkg.dataJAR-recipes/Postman/Postman.download.recipe</string>
 				<key>sha256_hash</key>
-				<string>8121b22b7a4370a9f49dcd797da13a14564e944b38b7a87066f4de3f0936e7a9</string>
+				<string>31aa97301c9211009904fb12659e16162e33cdc63c5fb1ff58ea2a2fdf87e9a3</string>
 			</dict>
 			<key>com.github.dataJAR-recipes.munki.postman</key>
 			<dict>
 				<key>git_hash</key>
-				<string>575fa7d279c228bae064fb0f355dd2af38fe5242</string>
+				<string>86f0ee3f3344a8895a39f2d6ab7c8ea0dad58e28</string>
 				<key>path</key>
-				<string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes/Postman/Postman.munki.recipe</string>
+				<string>~/work/automunki/automunki/autopkg_src/repos/com.github.autopkg.dataJAR-recipes/Postman/Postman.munki.recipe</string>
 				<key>sha256_hash</key>
-				<string>33c2ab8fc69022a46cdbd50207e61a1ca04125eba484b8c8a22f8d2fc476bd73</string>
+				<string>bda6e69a35a716d573565d0bde7b34536d40fcc89e0f80030218279f7d110bdf</string>
 			</dict>
 		</dict>
 	</dict>


### PR DESCRIPTION
autopkg_src/overrides/Postman.munki.recipe: FAILED
    Parent recipe com.github.dataJAR-recipes.download.postman contents differ from expected.
        Path: /Users/runner/work/automunki/automunki/autopkg_src/repos/com.github.autopkg.dataJAR-recipes/Postman/Postman.download.recipe
    commit 86f0ee3f3344a8895a39f2d6ab7c8ea0dad58e28
    Author: Kevin M. Cox <kevinmcox@users.noreply.github.com>
    Date:   Thu Jul 20 14:39:37 2023 -0500
    
        Postman updates (#286)
        
        This adds Munki's `supported_architectures` key.
    diff --git a/Postman/Postman.download.recipe b/Postman/Postman.download.recipe
    index 1f64841..7691427 100644
    --- a/Postman/Postman.download.recipe
    +++ b/Postman/Postman.download.recipe
    @@ -5,28 +5,29 @@
         <key>Description</key>
         <string>Downloads the current release version of Postman. Taken from bnpl-recipes repo. thanks to TSPARR for the Code Signature Check.
     
    -Set DOWNLOAD_URL with the required download url:
    -x86_64: https://dl.pstmn.io/download/latest/osx_64
    -arm64: https://dl.pstmn.io/download/latest/osx_arm64
    -</string>
    +For Intel set DOWNLOAD_ARCH to "64" (default)
    +
    +For Apple Silicon set DOWNLOAD_ARCH to "arm64"</string>
         <key>Identifier</key>
         <string>com.github.dataJAR-recipes.download.postman</string>
         <key>Input</key>
         <dict>
    -        <key>DOWNLOAD_URL</key>
    -        <string>https://dl.pstmn.io/download/latest/osx_64</string>
             <key>NAME</key>
             <string>Postman</string>
    +        <key>DOWNLOAD_ARCH</key>
    +        <string>64</string>
         </dict>
         <key>MinimumVersion</key>
    -    <string>1.0.0</string>
    +    <string>2.7.2</string>
         <key>Process</key>
         <array>
             <dict>
                 <key>Arguments</key>
                 <dict>
                     <key>url</key>
    -                <string>%DOWNLOAD_URL%</string>
    +                <string>https://dl.pstmn.io/download/latest/osx_%DOWNLOAD_ARCH%</string>
    +                <key>filename</key>
    +                <string>%NAME%-%SUPPORTED_ARCH%.zip</string>
                 </dict>
                 <key>Processor</key>
                 <string>URLDownloader</string>
    
    Parent recipe com.github.dataJAR-recipes.munki.postman contents differ from expected.
        Path: /Users/runner/work/automunki/automunki/autopkg_src/repos/com.github.autopkg.dataJAR-recipes/Postman/Postman.munki.recipe
    commit 86f0ee3f3344a8895a39f2d6ab7c8ea0dad58e28
    Author: Kevin M. Cox <kevinmcox@users.noreply.github.com>
    Date:   Thu Jul 20 14:39:37 2023 -0500
    
        Postman updates (#286)
        
        This adds Munki's `supported_architectures` key.
    diff --git a/Postman/Postman.munki.recipe b/Postman/Postman.munki.recipe
    index 4949b02..5e9c93b 100644
    --- a/Postman/Postman.munki.recipe
    +++ b/Postman/Postman.munki.recipe
    @@ -3,7 +3,11 @@
     <plist version="1.0">
     <dict>
         <key>Description</key>
    -    <string>Downloads the current release version of Postman, builds a package and imports it to Munki. Taken from bnpl-recipes repo</string>
    +    <string>Downloads the current release version of Postman, builds a DMG and imports it to Munki. Taken from bnpl-recipes repo
    +
    +For Intel set DOWNLOAD_ARCH to "64" and set SUPPORTED_ARCH to "x86_64" (default)
    +
    +For Apple Silicon set both DOWNLOAD_ARCH and SUPPORTED_ARCH to "arm64"</string>
         <key>Identifier</key>
         <string>com.github.dataJAR-recipes.munki.postman</string>
         <key>Input</key>
    @@ -12,6 +16,8 @@
             <string>developer</string>
             <key>NAME</key>
             <string>Postman</string>
    +        <key>SUPPORTED_ARCH</key>
    +        <string>x86_64</string>
             <key>pkginfo</key>
             <dict>
                 <key>catalogs</key>
    @@ -28,6 +34,10 @@
                 <string>Postman</string>
                 <key>name</key>
                 <string>%NAME%</string>
    +            <key>supported_architectures</key>
    +            <array>
    +                <string>%SUPPORTED_ARCH%</string>
    +            </array>
                 <key>unattended_install</key>
                 <true/>
                 <key>unattended_uninstall</key>
    @@ -35,7 +45,7 @@
             </dict>
         </dict>
         <key>MinimumVersion</key>
    -    <string>1.0.0</string>
    +    <string>2.7.2</string>
         <key>ParentRecipe</key>
         <string>com.github.dataJAR-recipes.download.postman</string>
         <key>Process</key>
    @@ -46,7 +56,7 @@
                 <key>Arguments</key>
                 <dict>
                     <key>dmg_path</key>
    -                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
    +                <string>%RECIPE_CACHE_DIR%/%NAME%-%SUPPORTED_ARCH%.dmg</string>
                     <key>dmg_root</key>
                     <string>%RECIPE_CACHE_DIR%/%NAME%</string>
                 </dict>
    
